### PR TITLE
Fix renamed readme in gemspec

### DIFF
--- a/newrelic_riak.gemspec
+++ b/newrelic_riak.gemspec
@@ -10,7 +10,6 @@ Gem::Specification.new do |gem|
   
   gem.add_runtime_dependency(%q<newrelic_rpm>, ["~> 3.0"])
   
-  gem.files = ["README.txt", "lib/newrelic_riak.rb", "lib/newrelic_riak/riak_client.rb", "lib/newrelic_riak/ripple.rb", "newrelic_riak.gemspec"]
+  gem.files = ["README.md", "lib/newrelic_riak.rb", "lib/newrelic_riak/riak_client.rb", "lib/newrelic_riak/ripple.rb", "newrelic_riak.gemspec"]
   gem.require_paths = ['lib']
 end
-


### PR DESCRIPTION
The readme file has been renamed from .txt to .md (which is good), but installing creates a warning since this file doesn't exist. This commit fixes the issue
